### PR TITLE
Add Kafka topics for likes and comments

### DIFF
--- a/kafka/producer.js
+++ b/kafka/producer.js
@@ -16,13 +16,23 @@ async function run() {
         console.log("Connected!")
 
 
+        // publish message to users topic
         const partition = msg[0] < "N" ? 0 : 1;
-
         const result = await producer.send({
             "topic": "Users",
             "messages": [{
                 "value": msg,
                 "partition": partition
+            }]
+        })
+        console.log(`Sent message: ${msg}`)
+        console.log(`Result: ${JSON.stringify(result)}`)
+
+        // publish message to likes topic
+        const result_like = await producer.send({
+            "topic": "Likes",
+            "messages": [{
+                "value": 1
             }]
         })
         console.log(`Sent message: ${msg}`)

--- a/kafka/topic.js
+++ b/kafka/topic.js
@@ -15,10 +15,16 @@ async function run() {
 
         // Users topic has 2 partitions: A-M, N-Z
         await admin.createTopics({
-            "topics": [{
-                "topic": "Users",
-                "numPartitions": 2
-            }]
+            "topics": [
+                {
+                    "topic": "Users",
+                    "numPartitions": 2
+                },
+                {
+                    "topic": "Likes",
+                    "numPartitions": 2
+                },
+            ]
         })
 
         console.log("Created successfully!")

--- a/kafka/topic.js
+++ b/kafka/topic.js
@@ -22,7 +22,11 @@ async function run() {
                 },
                 {
                     "topic": "Likes",
-                    "numPartitions": 2
+                    "numPartitions": 1
+                },
+                {
+                    "topic": "Comments",
+                    "numPartitions": 1
                 },
             ]
         })


### PR DESCRIPTION
Closes #1  

The purpose these changes is to add Kafka topics for likes and comments, as well as update the producer to publish messages to them.