### PR TITLE
Add kafka topics

### DIFF
--- a/kafka/consumer.js
+++ b/kafka/consumer.js
@@ -25,6 +25,18 @@ async function run() {
                 console.log(`Received message: ${result.message.value} on partition ${result.partition}`)
             }
         })
+
+        // test consuming message from events topic
+        consumer.subscribe({
+            "topic": "Events",
+            "fromBeginning": true
+        })
+
+        await consumer.run({
+            "eachMessage": async result => {
+                console.log(`Received message: ${result.message.value} on partition ${result.partition}`)
+            }
+        })
     } catch(ex) {
         console.error(`Something bad happened: ${ex}`)
     }

--- a/kafka/producer.js
+++ b/kafka/producer.js
@@ -38,6 +38,16 @@ async function run() {
         console.log(`Sent message: ${msg}`)
         console.log(`Result: ${JSON.stringify(result)}`)
 
+        // publish message to events topic
+        const result_event = await producer.send({
+            "topic": "Events",
+            "messages": [{
+                "value": "purchase"
+            }]
+        })
+        console.log(`Sent message: ${msg}`)
+        console.log(`Result: ${JSON.stringify(result)}`)
+
         await producer.disconnect()
     } catch(ex) {
         console.error(`Something bad happened: ${ex}`)

--- a/kafka/topic.js
+++ b/kafka/topic.js
@@ -28,6 +28,10 @@ async function run() {
                     "topic": "Comments",
                     "numPartitions": 1
                 },
+                {
+                    "topic": "Events",
+                    "numPartitions": 1
+                }
             ]
         })
 


### PR DESCRIPTION
Closes #3 

The purpose of these changes are to set up a new Kafka topic for stream processing of event data, and set up some tests for producing and consuming messages from this topic.